### PR TITLE
docs: add missing trailing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 {
   "folke/ts-comments.nvim",
-  opts = {}
+  opts = {},
   event = "VeryLazy",
   enabled = vim.fn.has("nvim-0.10.0") == 1,
 }


### PR DESCRIPTION
does not matter much, but here it goes `¯\_(ツ)_/¯`