### PR TITLE
fix: jsx comment toggling

### DIFF
--- a/lua/ts-comments/comments.lua
+++ b/lua/ts-comments/comments.lua
@@ -35,6 +35,9 @@ local function resolve(ft)
     local line = vim.fn.getline(".")
     local pos = vim.api.nvim_win_get_cursor(0)
     local indent = line:match("^%s*()")
+    -- nvim_win_get_cursor returns (1,0) indexed tuple
+    -- treesitter.get_node expects (0,0) indexed tuple
+    pos[1] = pos[1] - 1
     -- set position to the first non whitespace character
     if indent and pos[2] < indent - 1 then
       pos[2] = indent - 1


### PR DESCRIPTION
I noticed that toggling comments in jsx nodes had weird behavior

To repro you create a jsx or tsx file with the following content

```jsx
export function Comp() {
    return (
        <div>
                <span>hi</span>
        </div>
    )
}
```

If you place your cursor on `<span>` and trigger comment toggle `gcc` results in `// %s` comment applied instead of expected `{/* %s */}`.

Turns out `nvim_win_get_cursor` output and `treesitter.get_node`'s output are off by 1. With this change applied toggling comments on any line for this example file results in the correct comment string applied.

PS: Thanks for the great plugin!