### PR TITLE
feat(config): add support for proto and ft's without commentstring

### DIFF
--- a/lua/ts-comments/config.lua
+++ b/lua/ts-comments/config.lua
@@ -40,6 +40,7 @@ M.options = {
       statement_block = "// %s",
     },
     php = "// %s",
+    proto = { "// %s", "/* %s */" },
     rego = "# %s",
     rescript = "// %s",
     rust = { "// %s", "/* %s */" },
@@ -74,6 +75,9 @@ function M.setup(opts)
 
   ---@diagnostic disable-next-line: duplicate-set-field
   vim.filetype.get_option = function(filetype, option)
+    if filetype == "comment" then
+      filetype = vim.bo.filetype
+    end
     if option ~= "commentstring" then
       return M._get_option(filetype, option)
     end


### PR DESCRIPTION
## Description

Adds support for protofiles.
.proto files don't currently have a commentstring set in vim/neovim. This seems to make uncommenting work without
I have tested and it doesn't seem to break anything else.

## Related Issue(s)

  - Fixes #53 

