### PR TITLE
feat(config): add support for scss

### DIFF
--- a/lua/ts-comments/config.lua
+++ b/lua/ts-comments/config.lua
@@ -45,6 +45,7 @@ M.options = {
     rego = "# %s",
     rescript = "// %s",
     rust = { "// %s", "/* %s */" },
+    scss = { "// %s", "/* %s */" },
     sql = "-- %s",
     styled = "/* %s */",
     svelte = "<!-- %s -->",


### PR DESCRIPTION
## Description

<https://sass-lang.com/documentation/syntax/comments/>
SCSS supports both `// ...` and `/* ... */` comment syntax, but Neovim commentstring only provides `//`.
This PR adds `scss = { "// %s", "/* %s */" }` to the list to fix that.
