### PR TITLE
fix(vue): different comment strings for JS and HTML sections

### DIFF
--- a/lua/ts-comments/config.lua
+++ b/lua/ts-comments/config.lua
@@ -66,7 +66,10 @@ M.options = {
     },
     twig = "{# %s #}",
     typescript = { "// %s", "/* %s */" }, -- langs can have multiple commentstrings
-    vue = "<!-- %s -->",
+    vue = {
+      "<!-- %s -->",
+      script_element = "// %s",
+    },
     xaml = "<!-- %s -->",
   },
 }


### PR DESCRIPTION
Vue files contain also Javascript

## Description

Inside Vue files you normally have

```
<script>
// Javasciript
</script>

<template>
<!-- HTML -->
</template>
```

The first time you try to comment a line inside the `<script>` tag, it will be properly commented with `//`.
But when you try to uncomment it it will result in `<!-- // %s -->`.

By specifying the `script` Treesitter node, now Javascript code is always handled correcly inside Vue files.

## Related Issue(s)

I didn't open one since I thought it was easier to just fix the problem